### PR TITLE
chore: ptag-watchdog to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -25,3 +25,6 @@ dependencies:
 - name: proxy-service
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.29
+- name: ptag-watchdog
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.3


### PR DESCRIPTION
chore: Promote ptag-watchdog to version 0.0.3