### PR TITLE
chore: ptag-proxy-api to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -28,6 +28,9 @@ dependencies:
 - name: ptag-frontend
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.4
+- name: ptag-proxy-api
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.3
 - name: ptag-watchdog
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.3


### PR DESCRIPTION
chore: Promote ptag-proxy-api to version 0.0.3