### PR TITLE
chore: ptag-frontend to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -30,7 +30,7 @@ dependencies:
   version: 0.0.20
 - name: ptag-frontend
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6
 - name: ptag-proxy-api
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.4


### PR DESCRIPTION
chore: Promote ptag-frontend to version 0.0.6