### PR TITLE
chore: ptag-watchdog to 0.0.8

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -63,7 +63,7 @@ dependencies:
   version: 0.0.4
 - name: ptag-watchdog
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.7
+  version: 0.0.8
 - name: transaction-service
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.12


### PR DESCRIPTION
chore: Promote ptag-watchdog to version 0.0.8