### PR TITLE
chore: ptag-watchdog to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -78,7 +78,7 @@ dependencies:
   version: 0.0.4
 - name: ptag-watchdog
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.9
 - name: ptransaction-watchdog
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.6


### PR DESCRIPTION
chore: Promote ptag-watchdog to version 0.0.9