### PR TITLE
chore: ptag-proxy-api to 0.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -75,7 +75,7 @@ dependencies:
   version: 0.0.17
 - name: ptag-proxy-api
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.4
+  version: 0.0.5
 - name: ptag-watchdog
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.10


### PR DESCRIPTION
chore: Promote ptag-proxy-api to version 0.0.5