### PR TITLE
chore: ptag-watchdog to 0.0.16

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -81,7 +81,7 @@ dependencies:
   version: 0.0.5
 - name: ptag-watchdog
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.15
+  version: 0.0.16
 - name: ptransaction-watchdog
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.6


### PR DESCRIPTION
chore: Promote ptag-watchdog to version 0.0.16