### PR TITLE
chore: core-rule-engine-service to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 0.0.86
 - name: core-rule-engine-service
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6
 - name: core-sync-service
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.9


### PR DESCRIPTION
chore: Promote core-rule-engine-service to version 0.0.6