### PR TITLE
chore: ptag-log-proxy-api to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -78,7 +78,7 @@ dependencies:
   version: 0.0.18
 - name: ptag-log-proxy-api
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6
 - name: ptag-proxy-api
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.5


### PR DESCRIPTION
chore: Promote ptag-log-proxy-api to version 0.0.6