### PR TITLE
chore: ptag-proxy-api to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -84,7 +84,7 @@ dependencies:
   version: 0.0.6
 - name: ptag-proxy-api
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6
 - name: ptag-watchdog
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.16


### PR DESCRIPTION
chore: Promote ptag-proxy-api to version 0.0.6