### PR TITLE
chore: core-rule-engine-service to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -22,7 +22,7 @@ dependencies:
   version: 0.0.86
 - name: core-rule-engine-service
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.9
 - name: core-sync-service
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.9


### PR DESCRIPTION
chore: Promote core-rule-engine-service to version 0.0.9