### PR TITLE
chore: ptag-frontend to 0.0.22

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -78,7 +78,7 @@ dependencies:
   version: 0.0.32
 - name: ptag-frontend
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.19
+  version: 0.0.22
 - name: ptag-log-proxy-api
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.6


### PR DESCRIPTION
chore: Promote ptag-frontend to version 0.0.22