### PR TITLE
chore: keras-retinanet-dev to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -40,6 +40,9 @@ dependencies:
 - name: inventory-service
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.26
+- name: keras-retinanet-dev
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.3
 - name: model-service
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.30


### PR DESCRIPTION
chore: Promote keras-retinanet-dev to version 0.0.3